### PR TITLE
normalize base font size to $global-font-size on all screens

### DIFF
--- a/src/styles/components/_general.scss
+++ b/src/styles/components/_general.scss
@@ -7,21 +7,7 @@
 }
 
 html {
-	// Set font-size to 14px base
-	font-size: $global-font-size * 0.875;
-
-	@include tab() {
-		// Set font size to 16px base
-		font-size: $global-font-size;
-	}
-}
-
-body {
-	font-size: rem(14px);
-
-	@include tab() {
-		font-size: rem(16px);
-	}
+	font-size: $global-font-size;
 }
 
 html, body {


### PR DESCRIPTION
removes font-size shrink to 87.5% for `sm` screens