### PR TITLE
remove outer padding on pagination

### DIFF
--- a/src/styles/components/_paginator.scss
+++ b/src/styles/components/_paginator.scss
@@ -3,7 +3,7 @@
 .pagination {
     > ul {
         margin: 0;
-        padding: 0.25rem 0 0.65rem;
+        padding: 0;
         list-style: none;
 
         li {

--- a/src/styles/components/_paginator.scss
+++ b/src/styles/components/_paginator.scss
@@ -3,7 +3,6 @@
 .pagination {
     > ul {
         margin: 0;
-        padding: 0;
         list-style: none;
 
         li {


### PR DESCRIPTION
Removes outer padding from `pagination > ul`.  Top and bottom had different values which would cause incorrect alignment if used within a flexbox with `align-center`, and this allows any project using the component to set its own margins/padding.