### PR TITLE
Bug/calendar infinite month change

### DIFF
--- a/src/components/KsCalendar.vue
+++ b/src/components/KsCalendar.vue
@@ -29,9 +29,10 @@
             <span v-else class="ks-calendar-year-picker">{{year}}</span>
 
             <a v-if="showControls" href="#" @click.prevent="next" class="ctrl-right" ref="next">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 2 20 20">
-                    <path d="M12.95 10.707l.707-.707L8 4.343 6.586 5.757 10.828 10l-4.242 4.243L8 15.657l4.95-4.95z"/>
-                </svg>
+                &gt;
+<!--                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 2 20 20">-->
+<!--                    <path d="M12.95 10.707l.707-.707L8 4.343 6.586 5.757 10.828 10l-4.242 4.243L8 15.657l4.95-4.95z"/>-->
+<!--                </svg>-->
             </a>
         </div>
         <div

--- a/src/components/KsCalendar.vue
+++ b/src/components/KsCalendar.vue
@@ -29,10 +29,9 @@
             <span v-else class="ks-calendar-year-picker">{{year}}</span>
 
             <a v-if="showControls" href="#" @click.prevent="next" class="ctrl-right" ref="next">
-                &gt;
-<!--                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 2 20 20">-->
-<!--                    <path d="M12.95 10.707l.707-.707L8 4.343 6.586 5.757 10.828 10l-4.242 4.243L8 15.657l4.95-4.95z"/>-->
-<!--                </svg>-->
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 2 20 20">
+                    <path d="M12.95 10.707l.707-.707L8 4.343 6.586 5.757 10.828 10l-4.242 4.243L8 15.657l4.95-4.95z"/>
+                </svg>
             </a>
         </div>
         <div

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -7,14 +7,14 @@
  * @param event_capturing
  */
 export function addEvent(el, eventName, callback, event_capturing = false) {
-	if ( el.addEventListener ) {
-		el.addEventListener(eventName, callback, event_capturing);
-		if ( eventName == 'mousewheel' ) {
-			el.addEventListener("DOMMouseScroll", callback, event_capturing);
-		}
-	} else {
-		el.attachEvent(eventName, callback)
-	}
+    if ( el.addEventListener ) {
+        el.addEventListener(eventName, callback, event_capturing);
+        if ( eventName === 'mousewheel' ) {
+            el.addEventListener('DOMMouseScroll', callback, event_capturing);
+        }
+    } else {
+        el.attachEvent(eventName, callback);
+    }
 };
 
 /**
@@ -26,14 +26,14 @@ export function addEvent(el, eventName, callback, event_capturing = false) {
  * @param event_capturing
  */
 export function removeEvent(el, eventName, callback, event_capturing = false) {
-	if ( el.removeEventListener ) {
-		el.removeEventListener(eventName, callback, event_capturing);
-		if ( eventName == 'mousewheel' ) {
-			el.removeEventListener("DOMMouseScroll", callback, event_capturing);
-		}
-	} else {
-		el.detachEvent(eventName, callback)
-	}
+    if ( el.removeEventListener ) {
+        el.removeEventListener(eventName, callback, event_capturing);
+        if ( eventName == 'mousewheel' ) {
+            el.removeEventListener('DOMMouseScroll', callback, event_capturing);
+        }
+    } else {
+        el.detachEvent(eventName, callback);
+    }
 }
 
 /**
@@ -44,7 +44,7 @@ export function removeEvent(el, eventName, callback, event_capturing = false) {
  * @return {{focus}, {blur}}
  */
 export function smartFocusToggle(el, callback, delay = 150) {
-	const focused = [];
+    const focused = [];
     const smart_focus_toggle = {
         el,
         focus: (e) => {
@@ -63,8 +63,8 @@ export function smartFocusToggle(el, callback, delay = 150) {
                     }
                 }
             }, delay);
-        }
-    }
+        },
+    };
 
     addEvent(el, 'focus', smart_focus_toggle.focus, true);
     addEvent(el, 'blur', smart_focus_toggle.blur, true);
@@ -92,7 +92,7 @@ export function removeSmartFocusToggle(o) {
  * @returns {Number}
  */
 export function keyCode(e) {
-	return e.keyCode ? e.keyCode : e.charCode;
+    return e.keyCode ? e.keyCode : e.charCode;
 }
 
 /**
@@ -102,23 +102,23 @@ export function keyCode(e) {
  * @param el
  */
 export function stopParentScroll(el) {
-	addEvent(el, 'wheel', (e) => {
-		let offsetHeight = el.offsetHeight;
-		let scrollHeight = el.scrollHeight;
-		let scrollTop = el.scrollTop;
+    addEvent(el, 'wheel', (e) => {
+        let offsetHeight = el.offsetHeight;
+        let scrollHeight = el.scrollHeight;
+        let scrollTop = el.scrollTop;
 
-		if ( e.wheelDelta > 0 || e.deltaY < 0 ) {
-			if ( scrollTop == 0 ) {
-				e.preventDefault();
-			}
-		} else {
-			if ( offsetHeight + scrollTop >= scrollHeight ) {
-				e.preventDefault();
-			}
-		}
+        if ( e.wheelDelta > 0 || e.deltaY < 0 ) {
+            if ( scrollTop == 0 ) {
+                e.preventDefault();
+            }
+        } else {
+            if ( offsetHeight + scrollTop >= scrollHeight ) {
+                e.preventDefault();
+            }
+        }
 
-		e.stopPropagation();
-	});
+        e.stopPropagation();
+    });
 }
 
 /**
@@ -128,9 +128,9 @@ export function stopParentScroll(el) {
  * @returns {boolean}
  */
 export function scrolledToBottom(el, callback, delay = 100, threshold = 20) {
-	let timer;
+    let timer;
 
-	addEvent(el, 'scroll', (e) => {
+    addEvent(el, 'scroll', (e) => {
         clearTimeout(timer);
 
         // Using a timeout will prevent this from firing too often
@@ -139,7 +139,7 @@ export function scrolledToBottom(el, callback, delay = 100, threshold = 20) {
                 callback();
             }
         }, delay);
-	});
+    });
 }
 
 /**
@@ -154,13 +154,13 @@ export function isScrolledToBottom(el, threshold = 20) {
     let scrollHeight = el.scrollHeight;
 
     // For some reason the scroll gets triggered when containers are empty
-	// in that event we want to just return false
-	if ( scrollTop === 0 ) {
-		return false;
-	}
+    // in that event we want to just return false
+    if ( scrollTop === 0 ) {
+        return false;
+    }
 
-	// When scrolled to the bottom then we should run the next page
-	if ( scrollTop + offsetHeight >= scrollHeight - threshold ) {
+    // When scrolled to the bottom then we should run the next page
+    if ( scrollTop + offsetHeight >= scrollHeight - threshold ) {
         return true;
     }
 
@@ -176,52 +176,52 @@ export function isScrolledToBottom(el, threshold = 20) {
  * @param speed
  */
 export function mouseHold(el, callback, delay = 300, speed = 300) {
-	let held = false;
-	let poll_timer = null;
-	let delay_timer = null;
-	let _speed = speed;
-	// Lower is faster
-	let max_speed = 80;
+    let held = false;
+    let poll_timer = null;
+    let delay_timer = null;
+    let _speed = speed;
+    // Lower is faster
+    let max_speed = 80;
 
-	// Incrementing poll
-	function sendPoll() {
-		poll_timer = setTimeout(() => {
-			callback();
+    // Incrementing poll
+    function sendPoll() {
+        poll_timer = setTimeout(() => {
+            callback();
 
-			_speed = _speed * 0.925 > max_speed ? _speed * 0.925 : max_speed;
-			sendPoll();
-		}, _speed);
-	}
+            _speed = _speed * 0.925 > max_speed ? _speed * 0.925 : max_speed;
+            sendPoll();
+        }, _speed);
+    }
 
-	let clearMouseHold = () => {
+    let clearMouseHold = () => {
         clearTimeout(delay_timer);
         clearTimeout(poll_timer);
         held = false;
         _speed = speed;
     };
 
-	// mousedown to start the event
-	addEvent(el, 'mousedown', () => {
-		delay_timer = setTimeout(() => {
-			held = true;
-			if ( held === true ) {
-				sendPoll();
-			}
-		}, delay)
-	});
+    // mousedown to start the event
+    addEvent(el, 'mousedown', () => {
+        delay_timer = setTimeout(() => {
+            held = true;
+            if ( held === true ) {
+                sendPoll();
+            }
+        }, delay);
+    });
 
-	// mouseup to end the timers and reset the speed
+    // mouseup to end the timers and reset the speed
     addEvent(el, 'mouseup', clearMouseHold);
     addEvent(el, 'dragend', clearMouseHold);
 }
 
 export default {
-	addEvent,
-	smartFocusToggle,
+    addEvent,
+    smartFocusToggle,
     removeSmartFocusToggle,
-	keyCode,
-	stopParentScroll,
-	scrolledToBottom,
-	isScrolledToBottom,
-	mouseHold,
-}
+    keyCode,
+    stopParentScroll,
+    scrolledToBottom,
+    isScrolledToBottom,
+    mouseHold,
+};

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -180,16 +180,25 @@ export function mouseHold(el, callback, delay = 300, speed = 300) {
 	let poll_timer = null;
 	let delay_timer = null;
 	let _speed = speed;
+	// Lower is faster
+	let max_speed = 80;
 
 	// Incrementing poll
 	function sendPoll() {
 		poll_timer = setTimeout(() => {
 			callback();
 
-			_speed = _speed * 0.925;
+			_speed = _speed * 0.925 > max_speed ? _speed * 0.925 : max_speed;
 			sendPoll();
 		}, _speed);
 	}
+
+	let clearMouseHold = () => {
+        clearTimeout(delay_timer);
+        clearTimeout(poll_timer);
+        held = false;
+        _speed = speed;
+    };
 
 	// mousedown to start the event
 	addEvent(el, 'mousedown', () => {
@@ -202,12 +211,8 @@ export function mouseHold(el, callback, delay = 300, speed = 300) {
 	});
 
 	// mouseup to end the timers and reset the speed
-	addEvent(el, 'mouseup', () => {
-		clearTimeout(delay_timer);
-		clearTimeout(poll_timer);
-		held = false;
-		_speed = speed;
-	});
+    addEvent(el, 'mouseup', clearMouseHold);
+    addEvent(el, 'dragend', clearMouseHold);
 }
 
 export default {


### PR DESCRIPTION
Fixes issue where KsDatepicker would get stuck in an event loop changing months. Happens when holding down the mouse button on the month change and dragging it off of the calendar. That would prevent the mouseup event from firing which would leave the component infinitely changing months.