### PR TITLE
fixed event firing for the KsTab component

### DIFF
--- a/src/components/KsTab.vue
+++ b/src/components/KsTab.vue
@@ -31,7 +31,7 @@
 				parent.registerTab(this);
 				parent.$on('tab-changed', (title) => {
 					if ( title != this.title ) {
-						this.active = false;
+						this.setActive(false);
 					}
 				})
 			});


### PR DESCRIPTION
Fires event when tab is inactivated instead of just setting false. This will allow consumers to do cleanup on a tab becoming inactive