### PR TITLE
Bug/timepicker min time null

### DIFF
--- a/src/components/KsTimepicker.vue
+++ b/src/components/KsTimepicker.vue
@@ -48,6 +48,9 @@
     import ListIndexNavigator from './mixins/ListIndexNavigator';
     import {escapeRegExp} from '../helpers/strings';
 
+    const defaultMinTime = '04:00';
+    const defaultMaxTime = '23:59';
+
     export default {
         name: 'KsTimepicker',
 
@@ -75,11 +78,11 @@
             },
             minTime: {
                 type: String,
-                default: '04:00'
+                default: defaultMinTime
             },
             maxTime: {
                 type: String,
-                default: '23:59'
+                default: defaultMaxTime
             },
             endOfDay: {
                 type: Boolean,
@@ -98,8 +101,8 @@
              * @returns {Array}
              */
             timeOptions() {
-                let min_time = parseTime(this.minTime);
-                let max_time = parseTime(this.maxTime);
+                let min_time = parseTime(this.minTime ?? defaultMinTime);
+                let max_time = parseTime(this.maxTime ?? defaultMaxTime);
 
                 let options = [];
 

--- a/test/unit/Timepicker.test.js
+++ b/test/unit/Timepicker.test.js
@@ -84,3 +84,15 @@ test('Timepicker:filterDisplayValue matches left to right', t => {
 	t.true(vm.filterDisplayValue('01:00 pm'));
 	t.false(vm.filterDisplayValue('10:01 pm'));
 });
+
+test('Timepicker:min/max time can be null', t => {
+	resetDocument();
+
+	let vm = component(KsTimepicker, {
+		minTime: null,
+		maxTime: null,
+	});
+
+	t.deepEqual(vm.timeOptions[0], '04:00 am');
+	t.deepEqual(vm.timeOptions[vm.timeOptions.length - 1], '11:30 pm')
+});


### PR DESCRIPTION
When KsTimepicker is used with min/max time props set, null values passed by the parent cause parseTime errors in console. This is because in Vue the `default` prop value is not a true fallback value, rather it's only set when the prop is not passed at all by the parent.